### PR TITLE
Replace otherwise unused variable with function call in assertions

### DIFF
--- a/RSColorPicker/ColorPickerClasses/ANImageBitmapRep/BitmapContextRep.m
+++ b/RSColorPicker/ColorPickerClasses/ANImageBitmapRep/BitmapContextRep.m
@@ -79,9 +79,8 @@ BMPoint BMPointFromPoint (CGPoint point) {
 
 - (void)getRawPixel:(UInt8 *)rgba atPoint:(BMPoint)point {
 	size_t width = CGBitmapContextGetWidth(context);
-	size_t height = CGBitmapContextGetHeight(context);
 	NSAssert(point.x >= 0 && point.x < width, @"Point must be within bitmap.");
-	NSAssert(point.y >= 0 && point.y < height, @"Point must be within bitmap.");
+	NSAssert(point.y >= 0 && point.y < CGBitmapContextGetHeight(context), @"Point must be within bitmap.");
 	unsigned char * argbData = &bitmapData[((point.y * width) + point.x) * 4];
 	rgba[0] = argbData[1]; // red
 	rgba[1] = argbData[2]; // green
@@ -92,9 +91,8 @@ BMPoint BMPointFromPoint (CGPoint point) {
 
 - (void)setRawPixel:(const UInt8 *)rgba atPoint:(BMPoint)point {
 	size_t width = CGBitmapContextGetWidth(context);
-	size_t height = CGBitmapContextGetHeight(context);
 	NSAssert(point.x >= 0 && point.x < width, @"Point must be within bitmap.");
-	NSAssert(point.y >= 0 && point.y < height, @"Point must be within bitmap.");
+	NSAssert(point.y >= 0 && point.y < CGBitmapContextGetHeight(context), @"Point must be within bitmap.");
 	unsigned char * argbData = &bitmapData[((point.y * width) + point.x) * 4];
 	argbData[1] = rgba[0]; // red
 	argbData[2] = rgba[1]; // green


### PR DESCRIPTION
Since the height variable is only used inside an NSAssert, and NSAsserts are disabled by default in Release builds, this change prevents four warnings (two standard, two static analysis) against a product build.
