### PR TITLE
Fix warnings

### DIFF
--- a/RSColorPicker/ColorPickerClasses/ANImageBitmapRep/BitmapContextRep.h
+++ b/RSColorPicker/ColorPickerClasses/ANImageBitmapRep/BitmapContextRep.h
@@ -44,7 +44,7 @@ BMPoint BMPointFromPoint (CGPoint point);
 
 /**
  * Creates a bitmap context with the information from a CGImageRef.
- * @param image The image to use for initialization. The reference will
+ * @param img The image to use for initialization. The reference will
  * not be consumed, so you will still need to CGImageRelease() this as expected.
  */
 - (id)initWithCGImage:(CGImageRef)img;
@@ -77,7 +77,7 @@ BMPoint BMPointFromPoint (CGPoint point);
  * Tells the BitmapContext that a new image should be generated when
  * one is requested because the internal context has been externally
  * modified.
- * @param needsUpdate This should almost always be YES.  If this is no,
+ * @param flag This should almost always be YES.  If this is no,
  * a new CGImageRef will not be generated when one is requested.
  */
 - (void)setNeedsUpdate:(BOOL)flag;

--- a/RSColorPicker/ColorPickerClasses/BGRSLoupeLayer.m
+++ b/RSColorPicker/ColorPickerClasses/BGRSLoupeLayer.m
@@ -31,7 +31,7 @@
 #import "BGRSLoupeLayer.h"
 #import "RSColorPickerView.h"
 
-@interface BGRSLoupeLayer ()
+@interface BGRSLoupeLayer () <CAAnimationDelegate>
 
 @property (nonatomic) struct CGPath *gridCirclePath;
 


### PR DESCRIPTION
This fixes two semantic issues:
<img width="287" alt="Bildschirmfoto 2019-10-21 um 22 25 47" src="https://user-images.githubusercontent.com/1395240/67240447-c966da00-f451-11e9-8032-05c0260b35ba.png">

And brings two documentation comments in sync with the code.